### PR TITLE
紧急修复 物流塔额外参数

### DIFF
--- a/蓝图格式/物流塔额外参数Util.py
+++ b/蓝图格式/物流塔额外参数Util.py
@@ -65,7 +65,7 @@ class 带子出口(蓝图dataclass基类):
     def 转二进制数组(self):
         return [
             self.朝向.value,
-            self.接口建筑索引,
+            self.物品栏索引,
             0,
             0,
         ]


### PR DESCRIPTION
紧急修复 物流塔额外参数
该错误可能造成物流塔无法解析
由提交#21造成